### PR TITLE
Fix responseFile Convert empty object to array

### DIFF
--- a/src/Strategies/Responses/UseResponseFileTag.php
+++ b/src/Strategies/Responses/UseResponseFileTag.php
@@ -57,7 +57,12 @@ class UseResponseFileTag extends Strategy
             preg_match('/^(\d{3})?\s?([\S]*[\s]*?)(\{.*\})?$/', $responseFileTag->getContent(), $result);
             $status = $result[1] ?: 200;
             $content = $result[2] ? file_get_contents(storage_path(trim($result[2])), true) : '{}';
-            $json = ! empty($result[3]) ? str_replace("'", '"', $result[3]) : '{}';
+            
+            if (empty($result[3]) {
+              return [$content, (int) $status];
+            }
+            
+            $json = str_replace("'", '"', $result[3]);
             $merged = array_merge(json_decode($content, true), json_decode($json, true));
 
             return [json_encode($merged), (int) $status];


### PR DESCRIPTION
@responseFile tag now convert empty object to empty array
because of json_decode
Example:

{"foo":{}}

wil convert to 

{"foo":[]}